### PR TITLE
Configure to whitelist certain fields through env

### DIFF
--- a/routes/projects.js
+++ b/routes/projects.js
@@ -9,7 +9,6 @@ const whitelisted_fields =
 const router = express.Router();
 
 router.get('/', (req, res) => {
-  console.log(process.env.WHITELISTED_FIELDS);
   const fields = querystring.stringify({fields: whitelisted_fields});
   const url = `
     https://api.airtable.com/v0/app1f3lv9mx7L5xnY/Labs Project Tracking Staging?${fields}&

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -2,12 +2,14 @@ const express = require('express');
 const request = require('request');
 const querystring = require('querystring');
 const slug = require('slug');
+const whitelisted_fields = 
+  process.env.WHITELISTED_FIELDS.split(',') ||
+  ['customer','problem_statement','project_id','project_name','project_types','short_description','strategic_objectives'];
 
 const router = express.Router();
 
 router.get('/', (req, res) => {
-  const whitelisted_fields = 
-    ['customer','problem_statement','project_id','project_name','project_types','short_description','strategic_objectives'];
+  console.log(process.env.WHITELISTED_FIELDS);
   const fields = querystring.stringify({fields: whitelisted_fields});
   const url = `
     https://api.airtable.com/v0/app1f3lv9mx7L5xnY/Labs Project Tracking Staging?${fields}&


### PR DESCRIPTION
This pull request does the following: 
 - Defaults to a set of fields if no comma-separated WHITELISTED_FIELDS environment variable is set

### New environment variable: WHITELISTED_FIELDS
Comma-separated list of fields to pull from Airtable

