### PR TITLE
consume posts from nyc-planning-digital publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express": "^4.13.4",
     "kebab-case": "^1.0.0",
     "map-obj": "^3.0.0",
+    "moment": "^2.24.0",
     "node-fetch": "^2.3.0",
     "request": "^2.79.0",
     "rss-to-json": "^1.0.4",

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -5,7 +5,7 @@ const cheerio = require('cheerio');
 const router = express.Router();
 
 router.get('/', (req, res) => {
-  Feed.load('https://medium.com/feed/nycplanninglabs?truncated=true', (err, rss) => {
+  Feed.load('https://medium.com/feed/nyc-planning-digital/tagged/NYC%20Planning%20Labs?truncated=true', (err, rss) => {
     rss.items.map((item) => {
       const $ = cheerio.load(item.description);
       const parsedDescription = $('.medium-feed-snippet').text();

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -15,6 +15,8 @@ router.get('/', async (req, res) => {
   const items = [];
 
   $('.streamItem').each((i, streamItem) => {
+    if (i === 4) return false; // limit to 4 results
+
     const title = $(streamItem).find('h3').text();
 
     let description = $(streamItem).find('h4').text();
@@ -36,6 +38,8 @@ router.get('/', async (req, res) => {
       created,
       image,
     });
+
+    return true;
   });
 
   res.json({ items });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,6 +1433,10 @@ mocha@^5.2.0:
     mkdirp "0.5.1"
     supports-color "5.4.0"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
This PR updates the medium.com rss feed used by the `/posts` route.  Instead of the deprecated `nycplanninglabs` publication, it will consume the `nyc-planning-digital` publication with posts filtered for tag `NYC Planning Labs`

Do not merge until posts have been migrated to nyc-planning-digital on medium.
